### PR TITLE
Use package prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react": "^4.2.3",
     "express": "^4.13.4",
     "mocha": "^2.4.5",
+    "prop-types": "^15.6.0",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "rimraf": "^2.5.2",

--- a/src/BackgroundDef.js
+++ b/src/BackgroundDef.js
@@ -1,6 +1,5 @@
 import React from 'react'
-
-const {number, string, bool} = React.PropTypes
+import {number, string, bool} from 'prop-types'
 
 function getSize(props) {
   let width = props.diagonal

--- a/src/Hexagon.js
+++ b/src/Hexagon.js
@@ -1,7 +1,7 @@
 import React from 'react'
+import {number, string, object, node, func, bool} from 'prop-types'
 import BackgroundDef from './BackgroundDef'
 
-const {number, string, object, node, func, bool} = React.PropTypes
 const hexRatio = 0.868217054
 const numSides = 6
 const centerAng = 2 * Math.PI / numSides


### PR DESCRIPTION
Hello.

With react@16 out, we need to use package prop-types instead of React.PropTypes.